### PR TITLE
Add "false" text if variant is dark

### DIFF
--- a/templates/base16.mustache
+++ b/templates/base16.mustache
@@ -7,7 +7,4 @@
 # Configures difftool "delta" to ue light or dark mode based on the variant declared by the colorscheme.
 [delta]
     syntax-theme = "ansi"
-    light = {{ scheme-is-light-variant }}
-
-
-
+    light = {{#scheme-is-light-variant}}{{scheme-is-light-variant}}{{/scheme-is-light-variant}}{{^scheme-is-light-variant}}false{{/scheme-is-light-variant}}


### PR DESCRIPTION
currently the value is `light = true` for light themes and `light =` [for dark](https://github.com/tinted-theming/tinted-delta/blob/main/configs/base16-3024.gitconfig). This PR changes it to have `light = false` for dark themes. Alternatively we could have `light = true` for light and leave out the value entirely for dark.